### PR TITLE
Add Branding and Descriptor information to the Operator

### DIFF
--- a/bundle/manifests/sap-commerce-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sap-commerce-operator.clusterserviceversion.yaml
@@ -250,8 +250,8 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --v=10
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-                  - --v=10
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/manifests/bases/sap-commerce-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sap-commerce-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Application
     description: Building and running SAP Commerce in OpenShift
-    operators.operatorframework.io/builder: operator-sdk-v1.0.1+git
+    operators.operatorframework.io/builder: operator-sdk-v1.6.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/redhat-sap/sap-commerce-operator
     support: Red Hat


### PR DESCRIPTION
Need to add the Red Hat or Red Hat plus SAP partner logo to the operator as well as descriptor information to display when deployed.
- added descriptors for better UI experience
- added spec and status descriptors
- added operator logo and other display text on operator.
- added a readiness probe will make sure that pod starts entertaining requests only after it becomes ready from the application perspective
- Set LB type to source will ensure the same client-ip will reach the same source pod always until the pod goes down.

