### PR TITLE
load balancing strategy and readiness monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+testbin/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,13 +5,11 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=sap-commerce-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.bundle.channel.default.v1=
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.0.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.2+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/hybris.hybris.org_hybrisapps.yaml
+++ b/bundle/manifests/hybris.hybris.org_hybrisapps.yaml
@@ -30,14 +30,23 @@ spec:
         spec:
           description: HybrisAppSpec defines the desired state of HybrisApp
           properties:
+            apachejvmRouteName:
+              description: Hybris app Apache server.xml jvmRoute name
+              type: string
             baseImageName:
               description: Hybris base image name
               type: string
             baseImageTag:
               description: Hybris base image tag
               type: string
+            hybrisANTTaskNames:
+              description: Hybris app ANT tasks
+              type: string
             sourceRepoContext:
               description: Hybris app repository source location
+              type: string
+            sourceRepoLocalPropertiesOverride:
+              description: Hybris app repository local.properties override location
               type: string
             sourceRepoRef:
               description: Hybris app source repository reference

--- a/bundle/manifests/sap-commerce-operator-hybris-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/sap-commerce-operator-hybris-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: hybris-controller-manager
+  name: sap-commerce-operator-hybris-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: hybris-controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/sap-commerce-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sap-commerce-operator.clusterserviceversion.yaml
@@ -11,8 +11,11 @@ metadata:
             "name": "hybrisapp-sample"
           },
           "spec": {
+            "apachejvmRouteName": "",
             "baseImageName": "hybris-base",
-            "baseImageTag": "v0.1",
+            "baseImageTag": "v0.2",
+            "hybrisANTTaskNames": "",
+            "sourceRepoLocalPropertiesOverride": "",
             "sourceRepoRef": "master",
             "sourceRepoURL": "https://github.com/redhat-sap/sap-commerce-app-example.git"
           }
@@ -34,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.0.0
+    operators.operatorframework.io/builder: operator-sdk-v1.4.2+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: sap-commerce-operator.v0.0.1
   namespace: placeholder

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,11 +1,10 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: ""
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: sap-commerce-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.0.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.2+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
   operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/config/manifests/bases/sap-commerce-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sap-commerce-operator.clusterserviceversion.yaml
@@ -6,21 +6,21 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.0.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: sap-commerce-operator.vX.Y.Z
+  name: sap-commerce-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: HybrisBase is the Schema for the hybrisbases API
-      displayName: Hybris Base
-      kind: HybrisBase
-      name: hybrisbases.hybris.hybris.org
-      version: v1alpha1
     - description: HybrisApp is the Schema for the hybrisapps API
       displayName: Hybris App
       kind: HybrisApp
       name: hybrisapps.hybris.hybris.org
+      version: v1alpha1
+    - description: HybrisBase is the Schema for the hybrisbases API
+      displayName: Hybris Base
+      kind: HybrisBase
+      name: hybrisbases.hybris.hybris.org
       version: v1alpha1
   description: Sap Commerce Operator description. TODO.
   displayName: Sap Commerce Operator


### PR DESCRIPTION
- Adding a readiness probe will make sure that pod starts entertaining requests only after it becomes ready from the application perspective
- Setting LB type to source will ensure the same client-ip will reach the same source pod always until the pod goes down.

