### PR TITLE
ANT task should allow arguments to modify the task execution #22

### DIFF
--- a/base/s2i/assemble
+++ b/base/s2i/assemble
@@ -50,6 +50,7 @@ if [ ! -z "${HYBRIS_ANT_TASK_NAMES}" ]; then
     for v in ${HYBRIS_ANT_TASK_NAMES}
     do
         echo "---> Executing ANT $v"
+        IFS=" "
         ant $v
         if [ $? -ne 0 ]; then
             echo


### PR DESCRIPTION
Hybris ANT task should allow arguments to modify the task execution, defaults for startupProbe #22
The assemble script has been updated to allow parameters in the ANT tasks excuted