### PR TITLE
pin go version in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.0'
+          go-version: '1.16.0'
       - uses: docker/login-action@v1
         with:
           registry: quay.io


### PR DESCRIPTION
 - github action is configured to use the latest Go version (1.18), which is not supported by this operator.
 - pin the Go version to 1.16.0.